### PR TITLE
Automatically include groovy files in same folder

### DIFF
--- a/scriptjar.groovy
+++ b/scriptjar.groovy
@@ -38,7 +38,7 @@ List<GroovyClass> compile(String prefix, File file) {
 
     // compile groovy files in same folder
     getSiblingGroovyFiles(file).each {
-        CompilationUnit dependentUnit = new CompilationUnit(compilerConfig)
+        CompilationUnit dependentUnit = new CompilationUnit(compilerConfig, null, classLoader)
         def className = it.name.replaceAll(/\.groovy$/, '')
         println "${it.name} => ${className} (lib)"
         dependentUnit.addSource(SourceUnit.create(className, it.text))

--- a/scriptjar.groovy
+++ b/scriptjar.groovy
@@ -1,7 +1,5 @@
 #!/usr/bin/env groovy
 
-// from https://github.com/dmitart/scriptjar
-
 import groovy.grape.Grape
 import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.CompilerConfiguration

--- a/scriptjar.groovy
+++ b/scriptjar.groovy
@@ -1,12 +1,10 @@
 #!/usr/bin/env groovy
 
+// from https://github.com/dmitart/scriptjar
+
 import groovy.grape.Grape
-import org.codehaus.groovy.ast.*
-import org.codehaus.groovy.ast.stmt.EmptyStatement
-import org.codehaus.groovy.classgen.GeneratorContext
-import org.codehaus.groovy.control.CompilationFailedException
 import org.codehaus.groovy.control.CompilationUnit
-import org.codehaus.groovy.control.CompilationUnit.PrimaryClassNodeOperation
+import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.SourceUnit
 import org.codehaus.groovy.tools.GroovyClass
 
@@ -14,53 +12,56 @@ import java.util.jar.JarEntry
 import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
 
+import groovy.io.FileType
+
 import static org.codehaus.groovy.control.Phases.CLASS_GENERATION
-import static org.codehaus.groovy.control.Phases.SEMANTIC_ANALYSIS
-
-class RemoveStaticPrimaryClassNodeOperation extends PrimaryClassNodeOperation {
-
-    @Override
-    void call(SourceUnit source44, GeneratorContext context, ClassNode classNode) throws CompilationFailedException {
-        classNode.visitContents(new GroovyClassVisitor() {
-            @Override
-            void visitClass(ClassNode node) {
-            }
-
-            @Override
-            void visitConstructor(ConstructorNode node) {
-            }
-
-            @Override
-            void visitMethod(MethodNode node) {
-                if (node.name == '<clinit>') {
-                    node.setCode(new EmptyStatement())
-                }
-            }
-
-            @Override
-            void visitField(FieldNode node) {
-            }
-
-            @Override
-            void visitProperty(PropertyNode node) {
-            }
-        })
-    }
-}
 
 List<GroovyClass> compile(String prefix, File file) {
-    CompilationUnit unit = new CompilationUnit()
-    unit.addPhaseOperation(new RemoveStaticPrimaryClassNodeOperation(), SEMANTIC_ANALYSIS)
+    List<GroovyClass> classes = [] as List<GroovyClass>
+
+    // disable groovy grapes - we're resolving these ahead of time
+    CompilerConfiguration compilerConfig = new CompilerConfiguration()
+    Set disabledTransforms = ['groovy.grape.GrabAnnotationTransformation'] as Set
+    compilerConfig.setDisabledGlobalASTTransformations(disabledTransforms)
+
+    // compile main class
+    CompilationUnit unit = new CompilationUnit(compilerConfig)
     unit.addSource(SourceUnit.create(prefix, file.text))
+    println "${file.name} => ${prefix} (main class)"
     unit.compile(CLASS_GENERATION)
-    return unit.getClasses()
+    classes += unit.getClasses()
+
+    // compile groovy files in same folder
+    getSiblingGroovyFiles(file).each {
+        CompilationUnit dependentUnit = new CompilationUnit(compilerConfig)
+        def className = it.name.replaceAll(/\.groovy$/, '')
+        println "${it.name} => ${className} (lib)"
+        dependentUnit.addSource(SourceUnit.create(className, it.text))
+        dependentUnit.compile(CLASS_GENERATION)
+
+        classes += dependentUnit.getClasses()
+    }
+
+    return classes
+}
+
+List<File> getSiblingGroovyFiles(File mainGroovyFile) {
+    def groovyFileRe = /.*\.groovy$/
+    List<File> files = [] as List<File>
+    mainGroovyFile.getAbsoluteFile().getParentFile().eachFile(FileType.FILES) {
+        if (!it.hidden && it.name =~ groovyFileRe && it.name != mainGroovyFile.name && it.name != 'scriptJar.groovy') {
+            files << it
+        }
+    }
+
+    return files
 }
 
 List<File> getGroovyLibs(List neededJars) {
     def libs = new File('.')
     if (System.getenv('GROOVY_HOME')) {
         libs = new File(System.getenv('GROOVY_HOME'), 'lib')
-    }else if( System.getProperty("user.home") && 
+    }else if( System.getProperty("user.home") &&
               new File( System.getProperty("user.home"), '.groovy/grapes' ).exists() ) {
         libs = new File( System.getProperty("user.home"), '.groovy/grapes' )
     } else {
@@ -73,7 +74,7 @@ List<File> getGroovyLibs(List neededJars) {
     if (groovylibs) {
        return groovylibs
     } else {
-        println "Cann't find Groovy lib in ${libs.absolutePath}, specify it manually as Grab dependency"
+        println "Can't find Groovy lib in ${libs.absolutePath}, specify it manually as Grab dependency"
         System.exit(1)
     }
 }
@@ -81,8 +82,12 @@ List<File> getGroovyLibs(List neededJars) {
 List dependencies(File source) {
     final GroovyClassLoader classLoader = new GroovyClassLoader()
     classLoader.parseClass(source.text)
+    getSiblingGroovyFiles(source).each {
+      classLoader.parseClass(it.text)
+    }
     def files = Grape.resolve([:], Grape.listDependencies(classLoader)).collect{ new JarFile(it.path) }
     files.addAll(getGroovyLibs([/groovy-\d+.\d+.\d+.jar/]).collect{ new JarFile(it) })
+
     return files
 }
 
@@ -98,7 +103,9 @@ byte[] createJar(String prefix, List jars, List<GroovyClass> compiled) {
 
     jos.putNextEntry(new JarEntry('META-INF/'))
     writeJarEntry(jos, new JarEntry('META-INF/MANIFEST.MF'), "Manifest-Version: 1.0\nMain-Class: ${prefix}\n".getBytes())
-    compiled.each { writeJarEntry(jos, new JarEntry("${it.name}.class"), it.bytes) }
+    compiled.each {
+      writeJarEntry(jos, new JarEntry("${it.name}.class"), it.bytes)
+    }
 
     def directories = ['META-INF/', 'META-INF/MANIFEST.MF']
 


### PR DESCRIPTION
When you run groovy on a groovy script file, it includes groovy files in the same folder into the classpath.  This PR implements the same behavior once compiled to a jar, by compiling all of the sibling groovy files into the uberjar.  

Also, removed the `RemoveStaticPrimaryClassNodeOperation` class as this no longer worked as desired when utilizing actual groovy files with classes, because these often have legitimate static constructors.  I assumed the reason for this class was to prevent resolving grapes at runtime.  Added an alternate solution, which sets compiler configuration to ignore the grapes transformation.  